### PR TITLE
consider plugins that end with numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Configure a web server to serve `index.php`, for example with the following `.ht
 FallbackResource /index.php
 ```
 
-When using the built in webserver of PHP >=5.4.0 you can use
+When using the built in webserver of PHP >=5.4.0 you can use:
 
 ```
 php -S localhost:8000 index.php

--- a/php/Release.php
+++ b/php/Release.php
@@ -5,7 +5,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class Release
 {
-    const VERSION_REGEX = '|((?:\d+\.*){1,3})|';
+    const VERSION_REGEX = '|\.((?:\d+\.*){1,3})|';
 
     /** @var SplFileInfo $file */
     protected $file;


### PR DESCRIPTION
...like contact-form-7

`contact-form-7.1.2.3.zip` got picked up as version `7.1.2`
