### PR TITLE
List multiple versions in one row, and make container flexible

### DIFF
--- a/mustache/index.mustache
+++ b/mustache/index.mustache
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
 <body>
-<div class="container">
+<div class="container-fluid">
     <div class="page-header">
         <h1>Release Belt
             <small>{{host}}</small>
@@ -53,7 +53,7 @@
                 {{#packages}}
                     <tr>
                         <td>{{name}}</td>
-                        <td><a href="{{dist.url}}">{{version}}</a></td>
+                        <td><ul>{{#versions}}<li><a href="{{dist.url}}">{{version}}</a></li>{{/versions}}</ul></td>
                         <td>{{type}}</td>
                     </tr>
                 {{/packages}}

--- a/php/Controller.php
+++ b/php/Controller.php
@@ -15,8 +15,8 @@ class Controller
         $array = $this->getData($app);
         /** @var Request $request */
         $request              = $app['request_stack']->getCurrentRequest();
-        $composer          = new \stdClass();
-        $composer->require = [];
+        $composer             = new \stdClass();
+        $composer->require    = [];
         $packages             = [];
 
         foreach ($array['packages'] as $name => $versions) {
@@ -25,8 +25,12 @@ class Controller
             end($versions);
             $composer->require[$name] = '^' . key($versions);
 
-            $packages = array_merge($packages, array_values($versions));
+            $packages[$name]['name']      = $name;
+            $packages[$name]['type']      = $versions[key($versions)]['type'];
+            $packages[$name]['versions']  = array_values($versions);
         }
+
+        $packages = array_values($packages);
 
         $composer->repositories = [
             (object)[


### PR DESCRIPTION
Some changes to make viewing multiple versions of packages easier. Also make the whole page container be flexible width for a better layout with multiple versions of many packages.

Thanks for writing Release Belt, and I hope these PRs are as useful to you and others as they have been to me.