### PR TITLE
Echo the encoded password with an end of line character

### DIFF
--- a/bin/encodePassword.php
+++ b/bin/encodePassword.php
@@ -1,4 +1,4 @@
 <?php
 declare(strict_types=1);
 
-echo password_hash($argv[1], PASSWORD_DEFAULT);
+echo password_hash($argv[1], PASSWORD_DEFAULT) . PHP_EOL;


### PR DESCRIPTION
To help copying the encoded password the line should be ended properly.

Before:
```sh
~/release-belt $ php bin/encodePassword.php "foobar"
$2y$10$fooobarrr~/release-belt $
```

After:
```sh
~/release-belt $ php bin/encodePassword.php "foobar"
$2y$10$fooobarrr
~/release-belt $
```