### PR TITLE
Support `composer/installers` 2.x, in addition to the 1.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## Changed
+- Support `composer/installers` 2.x, in addition to the 1.x.
+
 ## 0.5 - 2019-11-21
 
 ### Added
@@ -48,7 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - command line boilerplate to home page.
 - site favicon, image from [Bytesize](https://danklammer.com/bytesize-icons/).
-- support for all `composer/installer` types (^1.5).
+- support for all `composer/installers` types (^1.5).
 - `users` configuration option with permission control by package path.
 - Composer script for updates.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It will serve the following Composer repository at `/packages.json` automagicall
                 },
                 "type": "wordpress-plugin",
                 "require": {
-                    "composer/installers": "^1.5"
+                    "composer/installers": "^1.5 || ^2.0"
                 }
             }
         }

--- a/src/Fractal/ReleaseTransformer.php
+++ b/src/Fractal/ReleaseTransformer.php
@@ -49,7 +49,7 @@ class ReleaseTransformer extends TransformerAbstract
 
         if (\in_array($release->type, $this->installerTypes, true)) {
             $package['require'] = [
-                'composer/installers' => '^1.5',
+                'composer/installers' => '^1.5 || ^2.0',
             ];
         }
 

--- a/tests/Fractal/ReleaseTransformerTest.php
+++ b/tests/Fractal/ReleaseTransformerTest.php
@@ -51,7 +51,7 @@ class ReleaseTransformerTest extends TestCase
             ],
             'type'    => $type,
             'require' => [
-                'composer/installers' => '^1.5',
+                'composer/installers' => '^1.5 || ^2.0',
             ],
         ], $transformResult);
     }


### PR DESCRIPTION
Similar to what has been done on WPackagist https://github.com/outlandishideas/wpackagist/pull/420

https://github.com/composer/installers/releases/tag/v2.0.0