### PR TITLE
Display 3 latest versions only with expandable toggle

### DIFF
--- a/src/Model/IndexModel.php
+++ b/src/Model/IndexModel.php
@@ -73,10 +73,13 @@ class IndexModel
         uksort($versions, 'version_compare');
         $versions = array_reverse($versions);
         $latest   = current(array_keys($versions));
-        $package  = [
-            'name'     => $name,
-            'latest'   => $latest,
-            'versions' => array_values($versions),
+        $allVersions = array_values($versions);
+        $package     = [
+            'name'            => $name,
+            'latest'          => $latest,
+            'versions'        => array_slice($allVersions, 0, 3),
+            'moreVersions'    => array_slice($allVersions, 3),
+            'hasMoreVersions' => count($allVersions) > 3,
         ];
 
         if (! empty($versions[$latest]['type'])) {

--- a/src/mustache/index.mustache
+++ b/src/mustache/index.mustache
@@ -69,6 +69,14 @@
                             <ul class="list-unstyled">
                                 {{#versions}}<li><a href="{{dist.url}}">{{version}}</a></li>{{/versions}}
                             </ul>
+                            {{#hasMoreVersions}}
+                            <details>
+                                <summary class="text-muted small">more…</summary>
+                                <ul class="list-unstyled">
+                                    {{#moreVersions}}<li><a href="{{dist.url}}">{{version}}</a></li>{{/moreVersions}}
+                                </ul>
+                            </details>
+                            {{/hasMoreVersions}}
                         </td>
                         <td>{{type}}</td>
                     </tr>

--- a/src/mustache/index.mustache
+++ b/src/mustache/index.mustache
@@ -7,6 +7,9 @@
     <link href="css/twbs/bootstrap/bootstrap.min.css" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <title>Release Belt — {{host}}</title>
+    <style>
+        details > summary { color: #6c757d; cursor: pointer; font-size: 80%; }
+    </style>
 </head>
 <body>
 <div class="container">
@@ -66,13 +69,13 @@
                     <tr>
                         <th scope="row" class="font-weight-normal">{{name}}</th>
                         <td>
-                            <ul class="list-unstyled">
+                            <ul class="list-unstyled mb-0">
                                 {{#versions}}<li><a href="{{dist.url}}">{{version}}</a></li>{{/versions}}
                             </ul>
                             {{#hasMoreVersions}}
                             <details>
-                                <summary class="text-muted small">more…</summary>
-                                <ul class="list-unstyled">
+                                <summary>more…</summary>
+                                <ul class="list-unstyled mt-1 mb-0">
                                     {{#moreVersions}}<li><a href="{{dist.url}}">{{version}}</a></li>{{/moreVersions}}
                                 </ul>
                             </details>

--- a/tests/Model/IndexModelTest.php
+++ b/tests/Model/IndexModelTest.php
@@ -35,26 +35,60 @@ class IndexModelTest extends TestCase
 
         $this->assertEquals([
             [
-                'name'     => 'package1',
-                'latest'   => '2.0',
-                'type'     => 'wordpress-plugin',
-                'versions' => [
+                'name'            => 'package1',
+                'latest'          => '2.0',
+                'type'            => 'wordpress-plugin',
+                'versions'        => [
                     [
                         'type' => 'wordpress-plugin',
                     ],
                     [],
                 ],
+                'moreVersions'    => [],
+                'hasMoreVersions' => false,
             ],
             [
-                'name'     => 'package2',
-                'latest'   => '1.1',
-                'versions' => [
+                'name'            => 'package2',
+                'latest'          => '1.1',
+                'versions'        => [
                     [
                         'foo' => 'bar',
                     ],
                 ],
-                'last'     => true,
+                'moreVersions'    => [],
+                'hasMoreVersions' => false,
+                'last'            => true,
             ],
         ], $context['packages']);
+    }
+
+    public function testGetContextWithManyVersions(): void
+    {
+        $packages = [
+            'package1' => [
+                '1.0' => ['v' => '1.0'],
+                '2.0' => ['v' => '2.0'],
+                '3.0' => ['v' => '3.0'],
+                '4.0' => ['v' => '4.0'],
+                '5.0' => ['v' => '5.0'],
+            ],
+        ];
+
+        $urlGeneratorDummy = $this->getMockBuilder(UrlGenerator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $indexModel = new IndexModel($packages, $urlGeneratorDummy);
+        $context    = $indexModel->getContext();
+
+        $this->assertCount(3, $context['packages'][0]['versions']);
+        $this->assertCount(2, $context['packages'][0]['moreVersions']);
+        $this->assertTrue($context['packages'][0]['hasMoreVersions']);
+        $this->assertEquals('5.0', $context['packages'][0]['latest']);
+        $this->assertEquals(['v' => '5.0'], $context['packages'][0]['versions'][0]);
+        $this->assertEquals(['v' => '4.0'], $context['packages'][0]['versions'][1]);
+        $this->assertEquals(['v' => '3.0'], $context['packages'][0]['versions'][2]);
+        $this->assertEquals(['v' => '2.0'], $context['packages'][0]['moreVersions'][0]);
+        $this->assertEquals(['v' => '1.0'], $context['packages'][0]['moreVersions'][1]);
     }
 }


### PR DESCRIPTION
This pull request improves how package versions are displayed in the index view by showing only the three most recent versions directly, with older versions accessible via a collapsible "more…" section. It also updates the underlying data model and tests to support this behavior.

**Display and UI improvements:**

* Only the three latest versions of each package are shown directly in the package list; additional versions are hidden under a "more…" expandable section using the `<details>` HTML element, improving readability for packages with many versions. (`src/mustache/index.mustache`)
* Added custom styling for the "more…" summary to make it visually distinct and user-friendly. (`src/mustache/index.mustache`)

**Backend/model changes:**

* Updated the `transformPackage` method to split versions into two lists: the three most recent (`versions`) and the rest (`moreVersions`), and added a `hasMoreVersions` flag to indicate when the expandable section should be shown. (`src/Model/IndexModel.php`)

**Testing:**

* Updated existing tests to check for the presence of the new `moreVersions` and `hasMoreVersions` fields in package context data. (`tests/Model/IndexModelTest.php`) [[1]](diffhunk://#diff-3c8e523d6795716cf3c0bacb1666c6d298e94330234450e3ca5b0a4be9bc776dR47-R48) [[2]](diffhunk://#diff-3c8e523d6795716cf3c0bacb1666c6d298e94330234450e3ca5b0a4be9bc776dR58-R93)